### PR TITLE
fix compilation errors in some compilers by adding the definition of M-PI

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,8 +6,9 @@ set(CMAKE_CXX_STANDARD 14)
 set(EXECUTABLE_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/bin)
 set(LIBRARY_OUTPUT_PATH ${PROJECT_SOURCE_DIR}/lib)
 
+add_compile_definitions(M_PI=3.14159265358979323846)
+
 if ("${CMAKE_CXX_COMPILER_ID}" STREQUAL "MSVC")
-    add_definitions( -D_USE_MATH_DEFINES=True)
     add_compile_options("$<$<C_COMPILER_ID:MSVC>:/utf-8>")
     add_compile_options("$<$<CXX_COMPILER_ID:MSVC>:/utf-8>")
 else()


### PR DESCRIPTION
As the title suggests, fix the error issue when compiling with some compilers such as clang, while also avoiding the IDE warning of not being able to find the M-PI. Tested on msvc, gcc, and clang